### PR TITLE
Fix shadow configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,16 +355,13 @@ subprojects {
             from components.java
           } else {
             apply plugin: 'com.gradleup.shadow'
-            project.shadow.component(mavenJava)
+            from components.shadow
 
             // Fix for avoiding inclusion of runtime dependencies marked as 'shadow' in MANIFEST Class-Path.
             // https://github.com/GradleUp/shadow/issues/324
             afterEvaluate {
               pom.withXml { xml ->
-                if (xml.asNode().get('dependencies') == null) {
-                  xml.asNode().appendNode('dependencies')
-                }
-                def dependenciesNode = xml.asNode().get('dependencies').get(0)
+                def dependenciesNode = xml.asNode().get('dependencies') ?: xml.asNode().appendNode('dependencies')
                 project.configurations.shadowed.allDependencies.each {
                   def dependencyNode = dependenciesNode.appendNode('dependency')
                   dependencyNode.appendNode('groupId', it.group)
@@ -1951,7 +1948,7 @@ project(':clients') {
     // dependencies excluded from the final jar, since they are declared as runtime dependencies
     dependencies {
       project.configurations.shadowed.allDependencies.each {
-        exclude(dependency(it.group + ':' + it.name))
+        exclude(dependency(it))
       }
       // exclude proto files from the jar
       exclude "**/opentelemetry/proto/**/*.proto"


### PR DESCRIPTION
```diff
diffuse diff --jar kafka-clients-4.1.0-SNAPSHOT-before.jar kafka-clients-4.1.0-SNAPSHOT-after.jar

OLD: kafka-clients-4.1.0-SNAPSHOT-before.jar
NEW: kafka-clients-4.1.0-SNAPSHOT-after.jar

 JAR   │ old       │ new       │ diff 
───────┼───────────┼───────────┼──────
 class │  23.2 MiB │  23.2 MiB │  0 B 
 other │ 503.3 KiB │ 503.3 KiB │  0 B 
───────┼───────────┼───────────┼──────
 total │  23.7 MiB │  23.7 MiB │  0 B 

 CLASSES │ old   │ new   │ diff      
─────────┼───────┼───────┼───────────
 classes │  3889 │  3889 │ 0 (+0 -0) 
 methods │ 56595 │ 56595 │ 0 (+0 -0) 
  fields │ 15708 │ 15708 │ 0 (+0 -0) 
```

```diff
diff kafka-clients-4.1.0-SNAPSHOT-before.pom kafka-clients-4.1.0-SNAPSHOT-after.pom

2a3,7
>   <!-- This module was also published with a richer model, Gradle metadata,  -->
>   <!-- which should be used instead. Do not delete the following line which  -->
>   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
>   <!-- that they should prefer consuming it instead. -->
>   <!-- do_not_remove: published-with-gradle-metadata -->
7d11
<   <packaging>pom</packaging>
```

Closes https://github.com/GradleUp/shadow/issues/1115.